### PR TITLE
Content/oct

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ downloads
 .pytest_cache
 .mypy_cache
 .requests_cache*
+__pycache__

--- a/docs/EVENT_TEMPLATE.md
+++ b/docs/EVENT_TEMPLATE.md
@@ -1,0 +1,39 @@
+# <MMM> - <SPEAKER_NAME>
+
+**Speaker**: <SPEAKER_NAME>
+
+**Talk Title:** <TITLE>
+
+![type:video](https://www.youtube.com/embed/<CODE>)
+
+!!! info "Event Details"
+
+    **Date/Time:**
+
+    Wednesday, April 20th, 2022 :material-clock: 11:00am ~ 12:00pm PT
+
+    :material-map-marker: **Location:**
+
+    Virtually on Zoom:
+
+    Link: <https://sfu.zoom.us/j/62763817981?pwd=cFJaVDN1a3U4NVJ5Uy9welZJazVWUT09>
+
+    Meeting ID: 627 6381 7981
+
+    Password: 735871
+
+**Affiliation:** <TODO>
+
+**Bio:**
+
+<TODO>
+
+**Abstract:**
+
+<TODO>
+
+---
+
+**Introductory Speaker:** <TODO>
+
+**Talk Title**: <TODO>

--- a/src/archive/2002/.pages
+++ b/src/archive/2002/.pages
@@ -1,0 +1,1 @@
+order: desc

--- a/src/archive/2003/.pages
+++ b/src/archive/2003/.pages
@@ -1,0 +1,1 @@
+order: desc

--- a/src/archive/2004/.pages
+++ b/src/archive/2004/.pages
@@ -1,0 +1,1 @@
+order: desc

--- a/src/archive/2005/.pages
+++ b/src/archive/2005/.pages
@@ -1,0 +1,1 @@
+order: desc

--- a/src/archive/2006/.pages
+++ b/src/archive/2006/.pages
@@ -1,0 +1,1 @@
+order: desc

--- a/src/archive/2007/.pages
+++ b/src/archive/2007/.pages
@@ -1,0 +1,1 @@
+order: desc

--- a/src/archive/2008/.pages
+++ b/src/archive/2008/.pages
@@ -1,0 +1,1 @@
+order: desc

--- a/src/archive/2009/.pages
+++ b/src/archive/2009/.pages
@@ -1,0 +1,1 @@
+order: desc

--- a/src/archive/2010/.pages
+++ b/src/archive/2010/.pages
@@ -1,0 +1,1 @@
+order: desc

--- a/src/archive/2011/.pages
+++ b/src/archive/2011/.pages
@@ -1,0 +1,1 @@
+order: desc

--- a/src/archive/2012/.pages
+++ b/src/archive/2012/.pages
@@ -1,0 +1,1 @@
+order: desc

--- a/src/archive/2013/.pages
+++ b/src/archive/2013/.pages
@@ -1,0 +1,1 @@
+order: desc

--- a/src/archive/2014/.pages
+++ b/src/archive/2014/.pages
@@ -1,0 +1,1 @@
+order: desc

--- a/src/archive/2015/.pages
+++ b/src/archive/2015/.pages
@@ -1,0 +1,1 @@
+order: desc

--- a/src/archive/2016/.pages
+++ b/src/archive/2016/.pages
@@ -1,0 +1,1 @@
+order: desc

--- a/src/archive/2017/.pages
+++ b/src/archive/2017/.pages
@@ -1,0 +1,1 @@
+order: desc

--- a/src/archive/2018/.pages
+++ b/src/archive/2018/.pages
@@ -1,0 +1,1 @@
+order: desc

--- a/src/archive/2019/.pages
+++ b/src/archive/2019/.pages
@@ -1,0 +1,1 @@
+order: desc

--- a/src/archive/2020/.pages
+++ b/src/archive/2020/.pages
@@ -1,0 +1,1 @@
+order: desc

--- a/src/archive/2021/.pages
+++ b/src/archive/2021/.pages
@@ -1,0 +1,1 @@
+order: desc

--- a/src/archive/2022/.pages
+++ b/src/archive/2022/.pages
@@ -1,0 +1,1 @@
+order: desc

--- a/src/archive/2022/2022-10-20.md
+++ b/src/archive/2022/2022-10-20.md
@@ -1,0 +1,33 @@
+# Oct - Jessica Dennis
+
+**Speaker**: Jessica Dennis
+
+**Talk Title:** Genetic epidemiology in the era of big data, biobanks, and -omic technologies.
+
+<!-- ![type:video](https://www.youtube.com/embed/<CODE>) -->
+
+!!! info "Event Details"
+
+    **Date/Time:**
+
+    October 20th, 2022, Thursday :material-clock: 6:00pm - 9:00pm PT
+
+    :material-map-marker:  St. Paul's Hospital Site: [Cullen Room (SPH1477)](https://drive.google.com/file/d/1VBdWxJj_WJeWCcdox4RY5wFWI2F5Gfgy/view?usp=sharing)
+
+**Affiliation:** Assistant Professor, Department of Medical Genetics, UBC and an Investigator at the BC Children’s Hospital Research Institute
+
+**Bio:**
+
+Jessica is an Assistant Professor in the Department of Medical Genetics at UBC and an Investigator at the BC Children’s Hospital Research Institute. A genetic epidemiologist by training, Jessica applies methods to emerging big data resources in population health. She aims to understand how genetic, , and environmental differences between people contribute to variation in disease susceptibility, to treatment, and recovery. A primary goal of her research is to reduce the suffering associated with psychiatric and disorders, which together account for more years lost to disability and death than either cancer or cardiovascular disease. She conducts studies in large population datasets, with a major interest in electronic health records and biobanks, and she works at the intersection of genetics, epidemiology, statistics, bioinformatics, and computer science. Jessica completed postdoctoral training in the Vanderbilt Genetics Institute at the Vanderbilt University Medical Center. She holds a PhD in Epidemiology from the University of Toronto, where she was a fellow in the interdisciplinary CIHR-STAGE program (Canadian Institutes of Health Research Strategic Training for Advanced Genetic Epidemiology). She also holds a MSc in Epidemiology from the University of Ottawa and a BSc in Biology (minor in Genetics) from the University of Guelph.
+
+**Abstract:**
+
+The last decade has seen an explosion of genomic and health-related data. This explosion has in large part has been fueled by the growth of large-scale biobanks, which are repositories of phenotype data linked to biospecimens (e.g., blood). Biobanks are designed to capture a range of data modalities, and are not designed with a single research question in mind. This core feature of biobank design enables a data-driven approach to quantifying, characterizing, and understanding the relationships between biospecimens and the phoneme. In this talk, I will highlight several large biobanking efforts worldwide, and the biological insights they are revealing. I will discuss results from a genome wide association study (GWAS) of loneliness using data from 23andMe and the UK Biobank, and follow-up analysis using polygenic scores and a phenome-wide association study in the Vanderbilt University Medical Center biobank. Finally, I will talk about recent work from my lab that integrates GWAS data with different omic data types to understand the prenatal origins of complex conditions such as asthma and ADHD. By the end of the talk, attendees should be able to: (i) discuss the typical objectives and study designs used in genetic epidemiology studies, and (ii) recognize different post-GWAS analysis options.
+
+---
+
+**Introductory Speaker:** Fiel Dimayacyac
+
+**Affiliation:** Pavlidis Lab
+
+**Talk Title:** Evaluating the Adequacy of Phylogenetic Comparative Methods for Gene Expression Data

--- a/src/index.md
+++ b/src/index.md
@@ -11,29 +11,7 @@ Visit our sister groups for bioinformatics events in Montreal ([MonBUG](https://
 
 ## VanBUG Seminar
 
-**Date:** Thursday, September 15th, 2022
-
-**Time:** 6:00 PM ~ 9:00 PM (Pacific Time)
-
-**Location:**  
-Room 1477 (Cullen), St. Paul's Hospital (SPH)  
-[1081 Burrard Street, Vancouver, BC V6Z 1Y6](https://goo.gl/maps/uCFbWCXcVrLmMnch7)  
-([local area map](https://drive.google.com/file/d/1VBdWxJj_WJeWCcdox4RY5wFWI2F5Gfgy/view)) 
-
-**Zoom meeting:**  
-https://sfu.zoom.us/j/68671911593?pwd=K3FrMGRxQWtxSi9pNWZ0U1g3OFQwdz09  
-Meeting ID: 686 7191 1593  
-Password: 636793  
-Dial by your location +1 778 907 2071 Canada  
-Find your local number: https://sfu.zoom.us/u/gcoe13ECLP  
-
-### Featured speaker: Dr. Geoffrey Schiebinger
-Assistant Professor, Department of Mathematics, UBC
-
-#### **Talk title:** Towards a mathematical theory of development
-
-**Talk abstract:**
-New measurement technologies like single-cell RNA sequencing are bringing 'big data' to biology. One of the most exciting prospects associated with this new trove of data is the possibility of studying temporal processes, such as differentiation and development. In this talk, we introduce the basic elements of a mathematical theory to answer questions like How does a stem cell transform into a muscle cell, a skin cell, or a neuron? How can we reprogram a skin cell into a neuron? We model a developing population of cells with a curve in the space of probability distributions on a high-dimensional gene expression space. We design algorithms to recover these curves from samples at various time-points and we collaborate closely with experimentalists to test these ideas on real data.
-
-**Speaker biography:**
-Geoffrey Schiebinger is an Assistant Professor of Mathematics, and an Associate Member of the School of Biomedical Engineering at the University of British Columbia. He graduated from Stanford in 2011 with a BS in Math and Physics and an MS in Electrical Engineering. He then went to Berkeley for graduate school, where he obtained his PhD in Statistics, under the supervision of Ben Recht. For postdoc, Geoff went to MIT to study with Aviv Regev, Eric Lander and Philippe Rigollet. Geoffrey has won numerous awards, including the 2021 Maud Menten Prize in Genetics (awarded to the new principal investigator with the highest ranking CIHR project grant), a 2019 Career Award at the Scientific Interface from the Burroughs Wellcome Fund, and an award for best contribution to the 2017 conference on Statistical Challenges in Single Cell Analysis.
+{%
+   include-markdown "./archive/2022/2022-10-20.md"
+   start="# Oct - Jessica Dennis"
+%}

--- a/src/schedule.md
+++ b/src/schedule.md
@@ -14,15 +14,15 @@
 
     Trainee Speaker: **TBA**
 
-- ### October 20th, 2022, Thursday
+- ### [October 20th, 2022, Thursday](./archive/2022/2022-10-20.md)
 
     :material-clock: 6:00pm - 9:00pm PT
 
     :material-map-marker:  St. Paul's Hospital Site: [Cullen Room (SPH1477)](https://drive.google.com/file/d/1VBdWxJj_WJeWCcdox4RY5wFWI2F5Gfgy/view?usp=sharing)
 
-    Featured Speaker: **TBA**
+    Featured Speaker: **Jessica Dennis**
 
-    Trainee Speaker: **TBA**
+    Trainee Speaker: **Fiel Dimayacyac**
 
 - ### November 17th, 2022, Thursday
 

--- a/src/schedule.md
+++ b/src/schedule.md
@@ -4,7 +4,7 @@
 
 <div class="timeline" markdown="1">
 
-- [September 15th, 2022, Thursday](./archive/2022/2022-09-15.md)
+- ### [September 15th, 2022, Thursday](./archive/2022/2022-09-15.md)
 
     :material-clock: 6:00pm - 9:00pm PT
 
@@ -14,7 +14,7 @@
 
     Trainee Speaker: **TBA**
 
-- October 20th, 2022, Thursday
+- ### October 20th, 2022, Thursday
 
     :material-clock: 6:00pm - 9:00pm PT
 
@@ -24,7 +24,7 @@
 
     Trainee Speaker: **TBA**
 
-- November 17th, 2022, Thursday
+- ### November 17th, 2022, Thursday
 
     :material-clock: 6:00pm - 9:00pm PT
 
@@ -34,7 +34,7 @@
 
     Trainee Speaker: **TBA**
 
-- December 8th, 2022, Thursday
+- ### December 8th, 2022, Thursday
 
     :material-clock: TBA
 

--- a/src/styles/timeline.css
+++ b/src/styles/timeline.css
@@ -20,7 +20,7 @@
   z-index: 1;
 }
 
-.timeline ul li>p {
+.timeline ul li>p, .timeline ul li>h3 {
   position: relative;
   bottom: 0;
   width: 600px;
@@ -32,7 +32,7 @@
 
 
 
-.timeline ul li>p:first-child {
+.timeline ul li>*:first-child {
   padding-top: 15px;
   border-top-left-radius: 5px;
   border-top-right-radius: 5px;
@@ -55,12 +55,12 @@
   border-style: solid;
 }
 
-.timeline ul li>p {
+.timeline ul li>p, .timeline ul li>h3 {
   left: 45px;
   margin: 0;
 }
 
-.timeline ul li>p::before {
+.timeline ul li>p::before, .timeline ul li>h3::before {
   left: -15px;
   border-width: 8px 16px 8px 0;
   border-color: transparent var(--md-accent-fg-color--light) transparent transparent;


### PR DESCRIPTION
- Adds new page for oct seminar
- reverses order of months pages in archive section so newest is at the top
![image](https://user-images.githubusercontent.com/4342641/191629880-88190f41-6ee4-4c80-aa98-babd495bdc73.png)

- makes schedule dates into headers so they can be hyperlinked to
![image](https://user-images.githubusercontent.com/4342641/191629852-0c7a2d50-f034-44aa-bee3-fd3841e05d37.png)

- adds a template markdown file for re-use in making the monthly pages