### PR TITLE
Fix seminar info

### DIFF
--- a/src/archive/2022/2022-10-20.md
+++ b/src/archive/2022/2022-10-20.md
@@ -14,7 +14,7 @@
 
     :material-map-marker:  St. Paul's Hospital Site: [Cullen Room (SPH1477)](https://drive.google.com/file/d/1VBdWxJj_WJeWCcdox4RY5wFWI2F5Gfgy/view?usp=sharing)
 
-**Affiliation:** Assistant Professor, Department of Medical Genetics, UBC and an Investigator at the BC Children’s Hospital Research Institute
+**Affiliations:** Assistant Professor, Department of Medical Genetics, UBC; Investigator, BC Children’s Hospital Research Institute
 
 **Bio:**
 

--- a/src/archive/2022/2022-10-20.md
+++ b/src/archive/2022/2022-10-20.md
@@ -1,8 +1,8 @@
 # Oct - Jessica Dennis
 
-**Speaker**: Jessica Dennis
+**Featured Speaker**: Jessica Dennis
 
-**Talk Title:** Genetic epidemiology in the era of big data, biobanks, and -omic technologies.
+**Talk Title:** Genetic epidemiology in the era of big data, biobanks, and -omic technologies
 
 <!-- ![type:video](https://www.youtube.com/embed/<CODE>) -->
 
@@ -18,16 +18,16 @@
 
 **Bio:**
 
-Jessica is an Assistant Professor in the Department of Medical Genetics at UBC and an Investigator at the BC Children’s Hospital Research Institute. A genetic epidemiologist by training, Jessica applies methods to emerging big data resources in population health. She aims to understand how genetic, , and environmental differences between people contribute to variation in disease susceptibility, to treatment, and recovery. A primary goal of her research is to reduce the suffering associated with psychiatric and disorders, which together account for more years lost to disability and death than either cancer or cardiovascular disease. She conducts studies in large population datasets, with a major interest in electronic health records and biobanks, and she works at the intersection of genetics, epidemiology, statistics, bioinformatics, and computer science. Jessica completed postdoctoral training in the Vanderbilt Genetics Institute at the Vanderbilt University Medical Center. She holds a PhD in Epidemiology from the University of Toronto, where she was a fellow in the interdisciplinary CIHR-STAGE program (Canadian Institutes of Health Research Strategic Training for Advanced Genetic Epidemiology). She also holds a MSc in Epidemiology from the University of Ottawa and a BSc in Biology (minor in Genetics) from the University of Guelph.
+Jessica is an Assistant Professor in the Department of Medical Genetics at UBC and an Investigator at the BC Children’s Hospital Research Institute. A genetic epidemiologist by training, Jessica applies methods to emerging big data resources in population health. She aims to understand how genetic, epigenetic, and environmental differences between people contribute to variation in disease susceptibility, to treatment, and recovery. A primary goal of her research is to reduce the suffering associated with psychiatric and neurological disorders, which together account for more years lost to disability and death than either cancer or cardiovascular disease. She conducts studies in large population datasets, with a major interest in electronic health records and biobanks, and she works at the intersection of genetics, epidemiology, statistics, bioinformatics, and computer science. Jessica completed postdoctoral training in the Vanderbilt Genetics Institute at the Vanderbilt University Medical Center. She holds a PhD in Epidemiology from the University of Toronto, where she was a fellow in the interdisciplinary CIHR-STAGE program (Canadian Institutes of Health Research Strategic Training for Advanced Genetic Epidemiology). She also holds a MSc in Epidemiology from the University of Ottawa and a BSc in Biology (minor in Genetics) from the University of Guelph.
 
 **Abstract:**
 
-The last decade has seen an explosion of genomic and health-related data. This explosion has in large part has been fueled by the growth of large-scale biobanks, which are repositories of phenotype data linked to biospecimens (e.g., blood). Biobanks are designed to capture a range of data modalities, and are not designed with a single research question in mind. This core feature of biobank design enables a data-driven approach to quantifying, characterizing, and understanding the relationships between biospecimens and the phoneme. In this talk, I will highlight several large biobanking efforts worldwide, and the biological insights they are revealing. I will discuss results from a genome wide association study (GWAS) of loneliness using data from 23andMe and the UK Biobank, and follow-up analysis using polygenic scores and a phenome-wide association study in the Vanderbilt University Medical Center biobank. Finally, I will talk about recent work from my lab that integrates GWAS data with different omic data types to understand the prenatal origins of complex conditions such as asthma and ADHD. By the end of the talk, attendees should be able to: (i) discuss the typical objectives and study designs used in genetic epidemiology studies, and (ii) recognize different post-GWAS analysis options.
+The last decade has seen an explosion of genomic and health-related data. This explosion has in large part been fueled by the growth of large-scale biobanks, which are repositories of phenotype data linked to biospecimens (e.g., blood). Biobanks are designed to capture a range of data modalities, and are not designed with a single research question in mind. This core feature of biobank design enables a data-driven approach to quantifying, characterizing, and understanding the relationships between biospecimens and the phoneme. In this talk, I will highlight several large biobanking efforts worldwide, and the biological insights they are revealing. I will discuss results from a genome wide association study (GWAS) of loneliness using data from 23andMe and the UK Biobank, and follow-up analysis using polygenic scores and a phenome-wide association study in the Vanderbilt University Medical Center biobank. Finally, I will talk about recent work from my lab that integrates GWAS data with different omic data types to understand the prenatal origins of complex conditions such as asthma and ADHD. By the end of the talk, attendees should be able to: (i) discuss the typical objectives and study designs used in genetic epidemiology studies, and (ii) recognize different post-GWAS analysis options.
 
 ---
 
-**Introductory Speaker:** Fiel Dimayacyac
+**Trainee Speaker:** Fiel Dimayacyac
 
-**Affiliation:** Pavlidis Lab
+**Affiliation:** Graduate Student, Dr. Paul Pavlidis Lab, UBC
 
-**Talk Title:** Evaluating the Adequacy of Phylogenetic Comparative Methods for Gene Expression Data
+**Talk Title:** Evaluating the adequacy of phylogenetic comparative methods for gene expression data


### PR DESCRIPTION
- correct typos in bio and abstract, i.e.
  - `... understand how genetic, , and environmental differences ...`
    - missing `epigenetic` between the commas
  - `... associated with psychiatric and disorders ...`
    - should be `psychiatric and neurological disorders`
  - `This explosion has in large part has been fueled...`
    - two `has`
- fix minor inconsistencies