### PR TITLE
November 2022 VanBUG - key speaker info

### DIFF
--- a/docs/EVENT_TEMPLATE.md
+++ b/docs/EVENT_TEMPLATE.md
@@ -1,9 +1,5 @@
 # <MMM> - <SPEAKER_NAME>
 
-**Speaker**: <SPEAKER_NAME>
-
-**Talk Title:** <TITLE>
-
 ![type:video](https://www.youtube.com/embed/<CODE>)
 
 !!! info "Event Details"
@@ -12,15 +8,19 @@
 
     Wednesday, April 20th, 2022 :material-clock: 11:00am ~ 12:00pm PT
 
-    :material-map-marker: **Location:**
+    :material-map-marker: **Location:** St. Paul's Hospital ([1081 Burrard Street, Vancouver, BC V6Z 1Y6](https://goo.gl/maps/uCFbWCXcVrLmMnch7)), Cullen Family Lecture Theatre ([Providence Building, Level 1, Room 1477](https://docs.google.com/document/d/1xHHd14LcrDIZLG7RGBGneLgf12H-FJwpyH7rotQCo9k/edit?usp=sharing))
 
-    Virtually on Zoom:
+    **Zoom Meeting:**
 
-    Link: <https://sfu.zoom.us/j/62763817981?pwd=cFJaVDN1a3U4NVJ5Uy9welZJazVWUT09>
+    <URL PENDING>
+    <br>Meeting ID: <PENDING>
+    <br>Password: <PENDING>
+    <br>Dial by your location <PENDING>
+    <br>Find your local number: <PENDING>
 
-    Meeting ID: 627 6381 7981
+**Featured Speaker**: <SPEAKER_NAME>
 
-    Password: 735871
+**Talk Title:** <TITLE>
 
 **Affiliation:** <TODO>
 
@@ -34,6 +34,8 @@
 
 ---
 
-**Introductory Speaker:** <TODO>
+**Trainee Speaker:** <TODO>
+
+**Affiliation:** <TODO>
 
 **Talk Title**: <TODO>

--- a/src/archive/2022/2022-11-17.md
+++ b/src/archive/2022/2022-11-17.md
@@ -1,0 +1,41 @@
+# Nov - Emma Griffiths
+
+![type:video](https://www.youtube.com/embed/<CODE>)
+
+!!! info "Event Details"
+
+    **Date/Time:**
+
+    Thursday, November 17th, 2022 :material-clock: 6:00pm - 9:00pm PT
+
+    :material-map-marker: **Location:** St. Paul's Hospital ([1081 Burrard Street, Vancouver, BC V6Z 1Y6](https://goo.gl/maps/uCFbWCXcVrLmMnch7)), Cullen Family Lecture Theatre ([Providence Building, Level 1, Room 1477](https://docs.google.com/document/d/1xHHd14LcrDIZLG7RGBGneLgf12H-FJwpyH7rotQCo9k/edit?usp=sharing))
+
+    **Zoom Meeting:**
+
+    <URL PENDING>
+    <br>Meeting ID: <PENDING>
+    <br>Password: <PENDING>
+    <br>Dial by your location <PENDING>
+    <br>Find your local number: <PENDING>
+
+**Speaker**: Emma Griffiths
+
+**Talk Title:** The CIDGOH public health pathogen genomics contextual data framework: how to cross the streams without the world imploding
+
+**Affiliation:** Ontology Project Coordinator, Lead Curator, and Research Associate, Centre for Infectious Disease Genomics and One Health at Simon Fraser University
+
+**Bio:**
+
+Dr. Emma Griffiths is a research associate in the Centre for Infectious Disease Genomics and One Health (Simon Fraser University) in Vancouver, Canada. Emma completed her PhD in Biochemistry at McMaster University (Ontario) studying bacterial phylogeny and evolutionary molecular markers. She also has postdoctoral experience in fungal and chemical genetics, as well as developing ontologies for infectious disease outbreak investigation and surveillance. Her work focuses on the development of data standards and ontologies to support public health and food safety pathogen genomics data curation, sharing and analyses.
+
+**Abstract:**
+
+During the COVID-19 pandemic, public health pathogen genomics played a critical role in tracking transmission, monitoring outbreaks both locally and globally, identifying variants of concern, providing data for the development of diagnostic tests and vaccines, and in understanding viral evolution and origins. In order to make use of pathogen sequence data, it must be interpreted using contextual data (metadata). Contextual data includes sample metadata, laboratory methods, patient demographics, clinical outcomes, and epidemiological information. However, the variability in how contextual information is captured and encoded by different organizations and databases poses challenges for data interpretation, integration, and its use/re-use. The Centre for Infectious Disease Genomics and One Health (CIDGOH) at Simon Fraser University developed a data specification as well as a curation/validation/data transformation tool called the DataHarmonizer which were used by members of the Canadian COVID Genomics Network (CanCOGeN) to harmonize SARS-CoV-2 contextual data for national surveillance and for public repository submission. In order to support coordination of international surveillance efforts, we have partnered with the Public Health Alliance for Genomic Epidemiology to make these resources available for use worldwide. The specification was also adapted for harmonizing Monkeypox data, and in conjunction with other harmonization projects for foodborne pathogens and wastewater, forms a framework for harmonizing public health contextual data. In this talk, we will describe the challenges and impact of variable contextual data in public health, the ontology approach to harmonization, the multi-pathogen framework currently being implemented, and the tools we have developed to put data standards into practice.
+
+---
+
+**Trainee Speaker:** Faeze Keshavarz-Rahaghi
+
+**Affiliation:** PhD Candidate, Dr. Steve Jones Lab, University of British Columbia
+
+**Talk Title**: <PENDING>

--- a/src/index.md
+++ b/src/index.md
@@ -12,6 +12,6 @@ Visit our sister groups for bioinformatics events in Montreal ([MonBUG](https://
 ## VanBUG Seminar
 
 {%
-   include-markdown "./archive/2022/2022-10-20.md"
-   start="# Oct - Jessica Dennis"
+   include-markdown "./archive/2022/2022-11-17.md"
+   start="# Nov - Emma Griffiths"
 %}


### PR DESCRIPTION
Created a November `.md` in the archive, included all available information on the event (all Key speaker info) and pointed `index.md` to it so that it appears on the front page of `vanbug.org`.