### PR TITLE
Updates to seminar pages

### DIFF
--- a/src/archive/2023/2023-01-19.md
+++ b/src/archive/2023/2023-01-19.md
@@ -8,6 +8,10 @@
 
     :material-map-marker: **Location:** St. Paul's Hospital ([1081 Burrard Street, Vancouver, BC V6Z 1Y6](https://goo.gl/maps/uCFbWCXcVrLmMnch7)), Cullen Family Lecture Theatre ([Providence Building, Level 1, Room 1477](https://docs.google.com/document/d/1xHHd14LcrDIZLG7RGBGneLgf12H-FJwpyH7rotQCo9k/edit?usp=sharing))
 
+    **RSVP**
+    
+    If you are interested in attending this seminar, please fill out [the RSVP form](https://forms.gle/edCDkrEPhDcoDKg3A).
+
     **Zoom Meeting:**
 
     <URL PENDING>
@@ -16,12 +20,11 @@
     <br>Dial by your location <PENDING>
     <br>Find your local number: <PENDING>
 
-**Speaker**: [Dr. Heng Li](https://www.google.com/url?q=https://www.dfhcc.harvard.edu/insider/member-detail/member/heng-li-phd/&sa=D&source=calendar&usd=2&usg=AOvVaw3C4rbtZy1rQjwtod27VqUP)
+**Featured Speaker**: [Dr. Heng Li](https://www.dfhcc.harvard.edu/insider/member-detail/member/heng-li-phd/)
+
+**Affiliations:** Associate Professor, Biomedical Informatics, Harvard Medical School; Assistant professor, Biostatistics and Computational Biology, Dana-Farber Cancer Institute
 
 **Talk Title:** PENDING
-
-
-**Affiliation:** Dana-Farber Cancer Institute; Associate Professor, Biomedical Informatics, Harvard Medical School; Assistant professor, Biostatistics and Computational Biology, Dana-Farber Cancer Institute
 
 **Bio:**
 
@@ -33,8 +36,8 @@ PENDING
 
 ---
 
-**Introductory Speaker:** [Dr. Melissa Chen](https://www.google.com/url?q=https://haneylab.com/lab-members/&sa=D&source=calendar&usd=2&usg=AOvVaw0elhw-eEcpokbVlupKj0mA)
+**Trainee Speaker:** [Dr. Melissa Chen](https://haneylab.com/lab-members/)
 
 **Affiliation:** Postdoctoral Fellow, Dr. Cara Haney Lab, University of British Columbia
 
-**Talk Title**: PENDING
+**Talk Title**: Predicting fungal infection rate and severity with skin-associated microbial communities on amphibians

--- a/src/archive/2023/2023-02-23.md
+++ b/src/archive/2023/2023-02-23.md
@@ -16,12 +16,11 @@
     <br>Dial by your location <PENDING>
     <br>Find your local number: <PENDING>
 
-**Speaker**: [Dr. Hosna Jabbari](https://www.google.com/url?q=https://www.uvic.ca/ecs/computerscience/people/faculty/profiles/jabbari-hosna.php&sa=D&source=calendar&usd=2&usg=AOvVaw0BDFut-qhS9Kg8YcRE4VbE)
-
-**Talk Title:** PENDING
-
+**Featured Speaker**: [Dr. Hosna Jabbari](https://www.google.com/url?q=https://www.uvic.ca/ecs/computerscience/people/faculty/profiles/jabbari-hosna.php&sa=D&source=calendar&usd=2&usg=AOvVaw0BDFut-qhS9Kg8YcRE4VbE)
 
 **Affiliation:** Assistant Professor, Computer Science, University of Victoria
+
+**Talk Title:** PENDING
 
 **Bio:**
 

--- a/src/archive/2023/2023-02-23.md
+++ b/src/archive/2023/2023-02-23.md
@@ -8,6 +8,10 @@
 
     :material-map-marker: **Location:** St. Paul's Hospital ([1081 Burrard Street, Vancouver, BC V6Z 1Y6](https://goo.gl/maps/uCFbWCXcVrLmMnch7)), Cullen Family Lecture Theatre ([Providence Building, Level 1, Room 1477](https://docs.google.com/document/d/1xHHd14LcrDIZLG7RGBGneLgf12H-FJwpyH7rotQCo9k/edit?usp=sharing))
 
+    **RSVP**
+
+    If you are interested in attending this seminar, please fill out [the RSVP form](https://forms.gle/FRwQJ4VS4t7JnPve7).
+
     **Zoom Meeting:**
 
     <URL PENDING>
@@ -16,7 +20,7 @@
     <br>Dial by your location <PENDING>
     <br>Find your local number: <PENDING>
 
-**Featured Speaker**: [Dr. Hosna Jabbari](https://www.google.com/url?q=https://www.uvic.ca/ecs/computerscience/people/faculty/profiles/jabbari-hosna.php&sa=D&source=calendar&usd=2&usg=AOvVaw0BDFut-qhS9Kg8YcRE4VbE)
+**Featured Speaker**: [Dr. Hosna Jabbari](https://www.uvic.ca/ecs/computerscience/people/faculty/profiles/jabbari-hosna.php)
 
 **Affiliation:** Assistant Professor, Computer Science, University of Victoria
 
@@ -32,7 +36,7 @@ PENDING
 
 ---
 
-**Trainee Speaker:** [Caralyn Reisle](https://www.google.com/url?q=https://ca.linkedin.com/in/caralyn-reisle&sa=D&source=calendar&usd=2&usg=AOvVaw2HCpbB02I8SubPu-zkp5sM)
+**Trainee Speaker:** [Caralyn Reisle](https://ca.linkedin.com/in/caralyn-reisle)
 
 **Affiliation:** PhD Candidate, Dr. Steven Jones Lab, University of British Columbia
 

--- a/src/archive/2023/2023-03-16.md
+++ b/src/archive/2023/2023-03-16.md
@@ -16,11 +16,11 @@
     <br>Dial by your location <PENDING>
     <br>Find your local number: <PENDING>
 
-**Speaker**: [Dr. Karin Verspoor](https://www.google.com/url?q=https://www.rmit.edu.au/contact/staff-contacts/academic-staff/v/verspoor-professor-karin&sa=D&source=calendar&usd=2&usg=AOvVaw23C_B9SP_ssfxO1lFVjaBl)
-
-**Talk Title:** PENDING
+**Featured Speaker**: [Dr. Karin Verspoor](https://www.google.com/url?q=https://www.rmit.edu.au/contact/staff-contacts/academic-staff/v/verspoor-professor-karin&sa=D&source=calendar&usd=2&usg=AOvVaw23C_B9SP_ssfxO1lFVjaBl)
 
 **Affiliation:** Dean, School of Computing Technologies, RMIT University in Melbourne, Australia
+
+**Talk Title:** PENDING
 
 **Bio:**
 

--- a/src/archive/2023/2023-03-16.md
+++ b/src/archive/2023/2023-03-16.md
@@ -8,6 +8,10 @@
 
     :material-map-marker: **Location:** St. Paul's Hospital ([1081 Burrard Street, Vancouver, BC V6Z 1Y6](https://goo.gl/maps/uCFbWCXcVrLmMnch7)), Cullen Family Lecture Theatre ([Providence Building, Level 1, Room 1477](https://docs.google.com/document/d/1xHHd14LcrDIZLG7RGBGneLgf12H-FJwpyH7rotQCo9k/edit?usp=sharing))
 
+    **RSVP**
+
+    If you are interested in attending this seminar, please fill out [the RSVP form](https://forms.gle/X633xrC1ybVW4Lme8).
+
     **Zoom Meeting:**
 
     <URL PENDING>
@@ -16,7 +20,7 @@
     <br>Dial by your location <PENDING>
     <br>Find your local number: <PENDING>
 
-**Featured Speaker**: [Dr. Karin Verspoor](https://www.google.com/url?q=https://www.rmit.edu.au/contact/staff-contacts/academic-staff/v/verspoor-professor-karin&sa=D&source=calendar&usd=2&usg=AOvVaw23C_B9SP_ssfxO1lFVjaBl)
+**Featured Speaker**: [Dr. Karin Verspoor](https://www.rmit.edu.au/contact/staff-contacts/academic-staff/v/verspoor-professor-karin)
 
 **Affiliation:** Dean, School of Computing Technologies, RMIT University in Melbourne, Australia
 
@@ -32,7 +36,7 @@ PENDING
 
 ---
 
-**Trainee Speaker:** [Andrew Galbraith](https://www.google.com/url?q=https://ca.linkedin.com/in/andrew-galbraith-168553200&sa=D&source=calendar&usd=2&usg=AOvVaw3kGZL9zGofoNKWTcrySzgz)
+**Trainee Speaker:** [Andrew Galbraith](https://ca.linkedin.com/in/andrew-galbraith-168553200)
 
 **Affiliation:** MSc Student, Dr. Steven Jones Lab, University of British Columbia
 

--- a/src/archive/2023/2023-04-20.md
+++ b/src/archive/2023/2023-04-20.md
@@ -8,6 +8,10 @@
 
     :material-map-marker: **Location:** St. Paul's Hospital ([1081 Burrard Street, Vancouver, BC V6Z 1Y6](https://goo.gl/maps/uCFbWCXcVrLmMnch7)), Cullen Family Lecture Theatre ([Providence Building, Level 1, Room 1477](https://docs.google.com/document/d/1xHHd14LcrDIZLG7RGBGneLgf12H-FJwpyH7rotQCo9k/edit?usp=sharing))
 
+    **RSVP**
+
+    If you are interested in attending this seminar, please fill out [the RSVP form](https://forms.gle/FZTes9e5gJcapAUC7).
+
     **Zoom Meeting:**
 
     <URL PENDING>
@@ -16,7 +20,7 @@
     <br>Dial by your location <PENDING>
     <br>Find your local number: <PENDING>
 
-**Featured Speaker**: [Dr. Yongjin Park](https://www.google.com/url?q=https://ypark.github.io/&sa=D&source=calendar&usd=2&usg=AOvVaw1VKqiCbeRuSy4FPzO5oqv3)
+**Featured Speaker**: [Dr. Yongjin Park](https://ypark.github.io/)
 
 **Affiliation:** Assistant Professor, Pathology and Statistics, University of British Columbia
 
@@ -32,7 +36,7 @@ PENDING
 
 ---
 
-**Trainee Speaker:** [Hans Ghezzi](https://www.google.com/url?q=http://tropini.microbiology.ubc.ca/who.html&sa=D&source=calendar&usd=2&usg=AOvVaw3oslstA5F8ncT8xQfpVAub)
+**Trainee Speaker:** [Hans Ghezzi](http://tropini.microbiology.ubc.ca/who.html)
 
 **Affiliation:** PhD Student, Dr. Carolina Tropini Lab, University of British Columbia
 

--- a/src/archive/2023/2023-04-20.md
+++ b/src/archive/2023/2023-04-20.md
@@ -16,11 +16,11 @@
     <br>Dial by your location <PENDING>
     <br>Find your local number: <PENDING>
 
-**Speaker**: [Dr. Yongjin Park](https://www.google.com/url?q=https://ypark.github.io/&sa=D&source=calendar&usd=2&usg=AOvVaw1VKqiCbeRuSy4FPzO5oqv3)
-
-**Talk Title:** PENDING
+**Featured Speaker**: [Dr. Yongjin Park](https://www.google.com/url?q=https://ypark.github.io/&sa=D&source=calendar&usd=2&usg=AOvVaw1VKqiCbeRuSy4FPzO5oqv3)
 
 **Affiliation:** Assistant Professor, Pathology and Statistics, University of British Columbia
+
+**Talk Title:** PENDING
 
 **Bio:**
 

--- a/src/archive/2023/2023-04-20.md
+++ b/src/archive/2023/2023-04-20.md
@@ -10,7 +10,7 @@
 
     **RSVP**
 
-    If you are interested in attending this seminar, please fill out [the RSVP form](https://forms.gle/FZTes9e5gJcapAUC7).
+    If you are interested in attending this seminar, please fill out [the RSVP form](https://forms.gle/FcJy8jGi3tu2egECA).
 
     **Zoom Meeting:**
 

--- a/src/index.md
+++ b/src/index.md
@@ -11,6 +11,6 @@ Visit our sister groups for bioinformatics events in Montreal ([MonBUG](https://
 ## VanBUG Seminar
 
 {%
-   include-markdown "./archive/2022/2022-11-17.md"
-   start="# Nov - Emma Griffiths"
+   include-markdown "./archive/2023/2023-01-19.md"
+   start="# Jan - Heng Li"
 %}


### PR DESCRIPTION
- update index page to point to January seminar page
- add links to RSVP forms for January~April seminars
- add January seminar trainee speaker talk title
- other minor edits