### PR TITLE
Date changes for Feb/Mar

### DIFF
--- a/src/archive/2023/2023-02-16.md
+++ b/src/archive/2023/2023-02-16.md
@@ -4,7 +4,7 @@
 
     **Date/Time:**
 
-    Thursday, February 23rd, 2023 :material-clock: 6:00pm - 9:00pm PT
+    Thursday, February 16th, 2023 :material-clock: 6:00pm - 9:00pm PT
 
     :material-map-marker: **Location:** St. Paul's Hospital ([1081 Burrard Street, Vancouver, BC V6Z 1Y6](https://goo.gl/maps/uCFbWCXcVrLmMnch7)), Cullen Family Lecture Theatre ([Providence Building, Level 1, Room 1477](https://docs.google.com/document/d/1xHHd14LcrDIZLG7RGBGneLgf12H-FJwpyH7rotQCo9k/edit?usp=sharing))
 

--- a/src/archive/2023/2023-03-09.md
+++ b/src/archive/2023/2023-03-09.md
@@ -4,7 +4,7 @@
 
     **Date/Time:**
 
-    Thursday, March 16th, 2023 :material-clock: 6:00pm - 9:00pm PT
+    Thursday, March 9th, 2023 :material-clock: 6:00pm - 9:00pm PT
 
     :material-map-marker: **Location:** St. Paul's Hospital ([1081 Burrard Street, Vancouver, BC V6Z 1Y6](https://goo.gl/maps/uCFbWCXcVrLmMnch7)), Cullen Family Lecture Theatre ([Providence Building, Level 1, Room 1477](https://docs.google.com/document/d/1xHHd14LcrDIZLG7RGBGneLgf12H-FJwpyH7rotQCo9k/edit?usp=sharing))
 

--- a/src/schedule.md
+++ b/src/schedule.md
@@ -14,7 +14,7 @@
     
     Introductory Speaker: **Dr. Melissa Chen (Cara Haney Lab)**
 
-- ### [February 16th, 2023, Thursday](./archive/2023/2023-02-23.md)
+- ### [February 16th, 2023, Thursday](./archive/2023/2023-02-16.md)
 
     :material-clock: 6:00pm - 9:00pm PT
 
@@ -24,7 +24,7 @@
 
     Trainee Speaker: **Caralyn Reisle (Steven Jones Lab)**
 
-- ### [March 9th, 2023, Thursday](./archive/2023/2023-03-16.md)
+- ### [March 9th, 2023, Thursday](./archive/2023/2023-03-09.md)
 
     :material-clock: 6:00pm - 9:00pm PT
 

--- a/src/schedule.md
+++ b/src/schedule.md
@@ -14,7 +14,7 @@
     
     Introductory Speaker: **Dr. Melissa Chen (Cara Haney Lab)**
 
-- ### [February 23rd, 2023, Thursday](./archive/2023/2023-02-23.md)
+- ### [February 16th, 2023, Thursday](./archive/2023/2023-02-23.md)
 
     :material-clock: 6:00pm - 9:00pm PT
 
@@ -24,7 +24,7 @@
 
     Trainee Speaker: **Caralyn Reisle (Steven Jones Lab)**
 
-- ### [March 16th, 2023, Thursday](./archive/2023/2023-03-16.md)
+- ### [March 9th, 2023, Thursday](./archive/2023/2023-03-16.md)
 
     :material-clock: 6:00pm - 9:00pm PT
 


### PR DESCRIPTION
Updated the dates on the schedule and archival pages. Didn't switch out the link on the main page yet since we don't yet have the talk info.